### PR TITLE
removing the about link on navbar

### DIFF
--- a/data/index.ts
+++ b/data/index.ts
@@ -246,7 +246,7 @@ export const Tools = [
 ];
 
 export const navData = [
-  { url: "/about", name: "About" },
+  // { url: "/about", name: "About" },
   // { url: "/projects", name: "Projects" },
   { url: "/blog", name: "Blog" },
 ];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Hides the About link from the site navigation.
> 
> - Comments out the `About` entry in `data/index.ts` `navData`, leaving only `Blog` visible
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab2756248eb4e560cd1b28e2684818e6958fa1c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->